### PR TITLE
feat: starts Home page estilization

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,3 +1,0 @@
-export function Home() {
-  return <h1>Home</h1>
-}

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,0 +1,38 @@
+import { Play } from 'phosphor-react'
+import {
+  CountdownContainer,
+  FormContainer,
+  HomeContainer,
+  Separator,
+} from './styles'
+
+export function Home() {
+  return (
+    <HomeContainer>
+      <form action="">
+        <FormContainer>
+          <label htmlFor="task">Vou trabalhar em</label>
+          <input id="task" />
+
+          <label htmlFor="minutesAmount">durante</label>
+          <input type="number" id="minutesAmount" />
+
+          <span>minutos</span>
+        </FormContainer>
+
+        <CountdownContainer>
+          <span>0</span>
+          <span>0</span>
+          <Separator>:</Separator>
+          <span>0</span>
+          <span>0</span>
+        </CountdownContainer>
+
+        <button type="submit">
+          <Play />
+          Começar
+        </button>
+      </form>
+    </HomeContainer>
+  )
+}

--- a/src/pages/Home/styles.ts
+++ b/src/pages/Home/styles.ts
@@ -1,0 +1,54 @@
+import styled from 'styled-components'
+
+export const HomeContainer = styled.main`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  flex: 1;
+
+  form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3.5rem;
+  }
+`
+
+export const FormContainer = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: ${(props) => props.theme['gray-100']};
+  font-size: 1.125rem;
+  font-weight: bold;
+  flex-wrap: wrap;
+`
+
+export const CountdownContainer = styled.div`
+  font-family: 'Roboto Mono', monospace;
+  font-size: 10rem;
+  line-height: 8rem;
+  color: ${(props) => props.theme['gray-100']};
+  display: flex;
+  gap: 1rem;
+
+  span {
+    background: ${(props) => props.theme['gray-700']};
+    padding: 2rem 1rem;
+    border-radius: 8px;
+  }
+`
+
+export const Separator = styled.div`
+  padding: 2rem 0;
+  color: ${(props) => props.theme['green-500']};
+  width: 4rem;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+`
+
+// export const button

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -15,6 +15,7 @@ export const GlobalStyle = createGlobalStyle`
     body {
         background: ${(props) => props.theme['gray-900']};
         color: ${(props) => props.theme['gray-300']};
+        -webkit-font-smoothing: antialiased;
     }
 
     body, input, textarea, button {


### PR DESCRIPTION
This PR starts the homepage styling. Includes part of the task form, 100% of the countdown and just the start button structure. Also, add sharpness to texts in webkit with `-webkit-font-smoothing: antialiased;` in global styles.