### PR TITLE
bugfix: reseta intervalo de ciclos anteriores

### DIFF
--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -48,12 +48,18 @@ export function Home() {
   const activeCycle = cycles.find((cycle) => cycle.id === activeCycleId)
 
   useEffect(() => {
+    let interval: number
+
     if (activeCycle) {
-      setInterval(() => {
+      interval = setInterval(() => {
         setAmountSecondsPassed(
-          differenceInSeconds(new Date(), activeCycle?.startDate),
+          differenceInSeconds(new Date(), activeCycle.startDate),
         )
       }, 1000)
+    }
+
+    return () => {
+      clearInterval(interval)
     }
   }, [activeCycle])
 
@@ -69,6 +75,7 @@ export function Home() {
 
     setCycles((state) => [...state, newCycle])
     setActiveCycleId(id)
+    setAmountSecondsPassed(0)
 
     reset()
   }


### PR DESCRIPTION
Agora, quando o usuário inicia um segundo ciclo, o cálculo de tempo do primeiro é descartado.